### PR TITLE
Bump genomad version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | module           | tools                | old versions | new versions          |
 | ---------------- | -------------------- | ------------ | --------------------- |
 | find_circles     | seqkit,samtools,gawk | 2.9.0, -, -  | 2.10.0, 1.21.0, 5.3.0 |
-| genomad/download | genomad              | -            | 1.7.4                 |
-| genomad/endtoend | genomad              | -            | 1.7.4                 |
+| genomad/download | genomad              | -            | 1.11.0                |
+| genomad/endtoend | genomad              | -            | 1.11.0                |
 
 ### `Deprecated`
 

--- a/modules.json
+++ b/modules.json
@@ -37,12 +37,12 @@
                     },
                     "genomad/download": {
                         "branch": "master",
-                        "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
+                        "git_sha": "5c9c6d55abdc05dbe3dc81b1cf4997d605c13795",
                         "installed_by": ["modules"]
                     },
                     "genomad/endtoend": {
                         "branch": "master",
-                        "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
+                        "git_sha": "5c9c6d55abdc05dbe3dc81b1cf4997d605c13795",
                         "installed_by": ["modules"]
                     },
                     "gtdbtk/classifywf": {

--- a/modules/nf-core/genomad/download/environment.yml
+++ b/modules/nf-core/genomad/download/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::genomad=1.7.4
+  - bioconda::genomad=1.11.0

--- a/modules/nf-core/genomad/download/main.nf
+++ b/modules/nf-core/genomad/download/main.nf
@@ -3,8 +3,8 @@ process GENOMAD_DOWNLOAD {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/genomad:1.7.4--pyhdfd78af_0':
-        'biocontainers/genomad:1.7.4--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/genomad:1.11.0--pyhdfd78af_0':
+        'biocontainers/genomad:1.11.0--pyhdfd78af_0' }"
 
     output:
     path "genomad_db/"  , emit: genomad_db

--- a/modules/nf-core/genomad/download/tests/main.nf.test.snap
+++ b/modules/nf-core/genomad/download/tests/main.nf.test.snap
@@ -42,7 +42,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,e98d6885d0b88a7a71f288fcff0b7b14"
+                    "versions.yml:md5,e8f595616ca5eb6e56dbd27f3583c809"
                 ],
                 "genomad_db": [
                     [
@@ -84,30 +84,31 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,e98d6885d0b88a7a71f288fcff0b7b14"
+                    "versions.yml:md5,e8f595616ca5eb6e56dbd27f3583c809"
                 ]
             }
         ],
-        "timestamp": "2024-01-03T17:41:56.803756044"
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-04-14T12:52:37.864190431"
     },
     "No input": {
         "content": [
             {
                 "0": [
                     [
-                        [
-                            "version-checkpoint.txt:md5,6527da533ace4cb4473cc907f265f170"
-                        ],
-                        "genomad_db:md5,b9ce17f8b01203c37a9147b5294dace6",
+                        "genomad_db:md5,ebc3abb4bd3df3c7c4ed222e883266af",
                         "genomad_db.dbtype:md5,f2dd0dedb2c260419ece4a9e03b2e828",
-                        "genomad_db.index:md5,5693ab7d5fe2c7947a9a43a9b5705f55",
-                        "genomad_db.lookup:md5,973c8434e0cf70593af1f888c4424876",
-                        "genomad_db.source:md5,6805958c7c99a8e8ab38095a40dc0081",
-                        "genomad_db_h:md5,1325d5db1da081c479a455a3e7440ae4",
+                        "genomad_db.index:md5,994923b4cfcfe168c1e26b4a7949ed3b",
+                        "genomad_db.lookup:md5,6617cc17bac380a54321dd4e68b890f5",
+                        "genomad_db.source:md5,ce61e4ec4bb80baeb4205c3e1bc424a3",
+                        "genomad_db_h:md5,fe6e0607c23fc9ffbfe349bd6f3d5153",
                         "genomad_db_h.dbtype:md5,740bab4f9ec8808aedb68d6b1281aeb2",
-                        "genomad_db_h.index:md5,8c14ed8d3b520be4cd22340a250d26bf",
-                        "genomad_db_mapping:md5,2e10dbb66f99183ff42092777a8089ca",
-                        "genomad_db_taxonomy:md5,5abcff23ab2efa5f5dcfc37cc55ccbbc",
+                        "genomad_db_h.index:md5,2ba89f264a735f0008b8c0fdb335825c",
+                        "genomad_db_mapping:md5,529a79b05c73606d24e5d463805fe5d2",
+                        "genomad_db_taxonomy:md5,c77b9d287e456fb73cfb5a6820aba06d",
                         "genomad_integrase_db:md5,23e19f271d2d65261588821a1e7d2b30",
                         "genomad_integrase_db.dbtype:md5,f2dd0dedb2c260419ece4a9e03b2e828",
                         "genomad_integrase_db.index:md5,7bae797a783d3f12c75845130ccb9b8a",
@@ -116,43 +117,40 @@
                         "genomad_integrase_db_h:md5,118e59c1b7bbbdfa6776c17da3db430b",
                         "genomad_integrase_db_h.dbtype:md5,740bab4f9ec8808aedb68d6b1281aeb2",
                         "genomad_integrase_db_h.index:md5,2e8987568dae1a3f4c0207657fd84205",
-                        "genomad_marker_metadata.tsv:md5,fcf64cdbfcd0e099b44143ff99133fed",
-                        "genomad_mini_db:md5,b9ce17f8b01203c37a9147b5294dace6",
+                        "genomad_marker_metadata.tsv:md5,a1a15aa0124d0b4d11ecf75bdec33c15",
+                        "genomad_mini_db:md5,ebc3abb4bd3df3c7c4ed222e883266af",
                         "genomad_mini_db.dbtype:md5,f2dd0dedb2c260419ece4a9e03b2e828",
-                        "genomad_mini_db.index:md5,e62e3de510ea7f5e73038f51ab02330f",
-                        "genomad_mini_db.lookup:md5,973c8434e0cf70593af1f888c4424876",
-                        "genomad_mini_db.source:md5,6805958c7c99a8e8ab38095a40dc0081",
-                        "genomad_mini_db_h:md5,1325d5db1da081c479a455a3e7440ae4",
+                        "genomad_mini_db.index:md5,11fbddf912fea0da671b42d39dc74c19",
+                        "genomad_mini_db.lookup:md5,6617cc17bac380a54321dd4e68b890f5",
+                        "genomad_mini_db.source:md5,ce61e4ec4bb80baeb4205c3e1bc424a3",
+                        "genomad_mini_db_h:md5,fe6e0607c23fc9ffbfe349bd6f3d5153",
                         "genomad_mini_db_h.dbtype:md5,740bab4f9ec8808aedb68d6b1281aeb2",
-                        "genomad_mini_db_h.index:md5,8c14ed8d3b520be4cd22340a250d26bf",
-                        "genomad_mini_db_mapping:md5,2e10dbb66f99183ff42092777a8089ca",
-                        "genomad_mini_db_taxonomy:md5,5abcff23ab2efa5f5dcfc37cc55ccbbc",
-                        "mini_set_ids:md5,9cc65ecf08bba29cd75e436b18f49e4b",
-                        "names.dmp:md5,83f879df06a69bf16687b5de575ed5ba",
-                        "nodes.dmp:md5,ee4db67cdcf75a5bba6a17b83e57425d",
-                        "plasmid_hallmark_annotation.txt:md5,b4c2568e65b1b8dc9b6f4e506b8ad402",
-                        "version.txt:md5,55a9f2aa32fbd44a46f3b190efa91312",
-                        "virus_hallmark_annotation.txt:md5,351e10e8593afa69d881b7a0128887e9"
+                        "genomad_mini_db_h.index:md5,2ba89f264a735f0008b8c0fdb335825c",
+                        "genomad_mini_db_mapping:md5,529a79b05c73606d24e5d463805fe5d2",
+                        "genomad_mini_db_taxonomy:md5,c77b9d287e456fb73cfb5a6820aba06d",
+                        "mini_set_ids:md5,568e32f9672886f797cf067baf9cf076",
+                        "names.dmp:md5,516b050055edb829670e1273d3294c84",
+                        "nodes.dmp:md5,16009b88dfc13b192444b9e45e840f88",
+                        "plasmid_hallmark_annotation.txt:md5,fd5f9e1e2eecc75412c6452d225ca3af",
+                        "version.txt:md5,6e11601fb5d98a9eb5dab9924c681bdf",
+                        "virus_hallmark_annotation.txt:md5,c049e710fa5b3462bc27a89f37f112bd"
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,e98d6885d0b88a7a71f288fcff0b7b14"
+                    "versions.yml:md5,e8f595616ca5eb6e56dbd27f3583c809"
                 ],
                 "genomad_db": [
                     [
-                        [
-                            "version-checkpoint.txt:md5,6527da533ace4cb4473cc907f265f170"
-                        ],
-                        "genomad_db:md5,b9ce17f8b01203c37a9147b5294dace6",
+                        "genomad_db:md5,ebc3abb4bd3df3c7c4ed222e883266af",
                         "genomad_db.dbtype:md5,f2dd0dedb2c260419ece4a9e03b2e828",
-                        "genomad_db.index:md5,5693ab7d5fe2c7947a9a43a9b5705f55",
-                        "genomad_db.lookup:md5,973c8434e0cf70593af1f888c4424876",
-                        "genomad_db.source:md5,6805958c7c99a8e8ab38095a40dc0081",
-                        "genomad_db_h:md5,1325d5db1da081c479a455a3e7440ae4",
+                        "genomad_db.index:md5,994923b4cfcfe168c1e26b4a7949ed3b",
+                        "genomad_db.lookup:md5,6617cc17bac380a54321dd4e68b890f5",
+                        "genomad_db.source:md5,ce61e4ec4bb80baeb4205c3e1bc424a3",
+                        "genomad_db_h:md5,fe6e0607c23fc9ffbfe349bd6f3d5153",
                         "genomad_db_h.dbtype:md5,740bab4f9ec8808aedb68d6b1281aeb2",
-                        "genomad_db_h.index:md5,8c14ed8d3b520be4cd22340a250d26bf",
-                        "genomad_db_mapping:md5,2e10dbb66f99183ff42092777a8089ca",
-                        "genomad_db_taxonomy:md5,5abcff23ab2efa5f5dcfc37cc55ccbbc",
+                        "genomad_db_h.index:md5,2ba89f264a735f0008b8c0fdb335825c",
+                        "genomad_db_mapping:md5,529a79b05c73606d24e5d463805fe5d2",
+                        "genomad_db_taxonomy:md5,c77b9d287e456fb73cfb5a6820aba06d",
                         "genomad_integrase_db:md5,23e19f271d2d65261588821a1e7d2b30",
                         "genomad_integrase_db.dbtype:md5,f2dd0dedb2c260419ece4a9e03b2e828",
                         "genomad_integrase_db.index:md5,7bae797a783d3f12c75845130ccb9b8a",
@@ -161,30 +159,34 @@
                         "genomad_integrase_db_h:md5,118e59c1b7bbbdfa6776c17da3db430b",
                         "genomad_integrase_db_h.dbtype:md5,740bab4f9ec8808aedb68d6b1281aeb2",
                         "genomad_integrase_db_h.index:md5,2e8987568dae1a3f4c0207657fd84205",
-                        "genomad_marker_metadata.tsv:md5,fcf64cdbfcd0e099b44143ff99133fed",
-                        "genomad_mini_db:md5,b9ce17f8b01203c37a9147b5294dace6",
+                        "genomad_marker_metadata.tsv:md5,a1a15aa0124d0b4d11ecf75bdec33c15",
+                        "genomad_mini_db:md5,ebc3abb4bd3df3c7c4ed222e883266af",
                         "genomad_mini_db.dbtype:md5,f2dd0dedb2c260419ece4a9e03b2e828",
-                        "genomad_mini_db.index:md5,e62e3de510ea7f5e73038f51ab02330f",
-                        "genomad_mini_db.lookup:md5,973c8434e0cf70593af1f888c4424876",
-                        "genomad_mini_db.source:md5,6805958c7c99a8e8ab38095a40dc0081",
-                        "genomad_mini_db_h:md5,1325d5db1da081c479a455a3e7440ae4",
+                        "genomad_mini_db.index:md5,11fbddf912fea0da671b42d39dc74c19",
+                        "genomad_mini_db.lookup:md5,6617cc17bac380a54321dd4e68b890f5",
+                        "genomad_mini_db.source:md5,ce61e4ec4bb80baeb4205c3e1bc424a3",
+                        "genomad_mini_db_h:md5,fe6e0607c23fc9ffbfe349bd6f3d5153",
                         "genomad_mini_db_h.dbtype:md5,740bab4f9ec8808aedb68d6b1281aeb2",
-                        "genomad_mini_db_h.index:md5,8c14ed8d3b520be4cd22340a250d26bf",
-                        "genomad_mini_db_mapping:md5,2e10dbb66f99183ff42092777a8089ca",
-                        "genomad_mini_db_taxonomy:md5,5abcff23ab2efa5f5dcfc37cc55ccbbc",
-                        "mini_set_ids:md5,9cc65ecf08bba29cd75e436b18f49e4b",
-                        "names.dmp:md5,83f879df06a69bf16687b5de575ed5ba",
-                        "nodes.dmp:md5,ee4db67cdcf75a5bba6a17b83e57425d",
-                        "plasmid_hallmark_annotation.txt:md5,b4c2568e65b1b8dc9b6f4e506b8ad402",
-                        "version.txt:md5,55a9f2aa32fbd44a46f3b190efa91312",
-                        "virus_hallmark_annotation.txt:md5,351e10e8593afa69d881b7a0128887e9"
+                        "genomad_mini_db_h.index:md5,2ba89f264a735f0008b8c0fdb335825c",
+                        "genomad_mini_db_mapping:md5,529a79b05c73606d24e5d463805fe5d2",
+                        "genomad_mini_db_taxonomy:md5,c77b9d287e456fb73cfb5a6820aba06d",
+                        "mini_set_ids:md5,568e32f9672886f797cf067baf9cf076",
+                        "names.dmp:md5,516b050055edb829670e1273d3294c84",
+                        "nodes.dmp:md5,16009b88dfc13b192444b9e45e840f88",
+                        "plasmid_hallmark_annotation.txt:md5,fd5f9e1e2eecc75412c6452d225ca3af",
+                        "version.txt:md5,6e11601fb5d98a9eb5dab9924c681bdf",
+                        "virus_hallmark_annotation.txt:md5,c049e710fa5b3462bc27a89f37f112bd"
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,e98d6885d0b88a7a71f288fcff0b7b14"
+                    "versions.yml:md5,e8f595616ca5eb6e56dbd27f3583c809"
                 ]
             }
         ],
-        "timestamp": "2024-01-03T17:38:10.13471002"
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-04-14T12:51:48.507839409"
     }
 }

--- a/modules/nf-core/genomad/endtoend/environment.yml
+++ b/modules/nf-core/genomad/endtoend/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::genomad=1.7.4
+  - bioconda::genomad=1.11.0

--- a/modules/nf-core/genomad/endtoend/main.nf
+++ b/modules/nf-core/genomad/endtoend/main.nf
@@ -4,8 +4,8 @@ process GENOMAD_ENDTOEND {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/genomad:1.7.4--pyhdfd78af_0':
-        'biocontainers/genomad:1.7.4--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/genomad:1.11.0--pyhdfd78af_0':
+        'biocontainers/genomad:1.11.0--pyhdfd78af_0' }"
 
     input:
     tuple val(meta) , path(fasta)

--- a/modules/nf-core/genomad/endtoend/tests/main.nf.test.snap
+++ b/modules/nf-core/genomad/endtoend/tests/main.nf.test.snap
@@ -9,7 +9,7 @@
                     {
                         "id": "test"
                     },
-                    "genome_taxonomy.tsv:md5,44c6cf5ff4c836f66648457ae8deb0d5"
+                    "genome_taxonomy.tsv:md5,be8ac66e3ea3a89ee6f41e08db79d0d6"
                 ]
             ],
             [
@@ -52,7 +52,7 @@
                     {
                         "id": "test"
                     },
-                    "genome_virus_genes.tsv:md5,f84d8a9fce3c92c49e78672bea16561f"
+                    "genome_virus_genes.tsv:md5,f7970779d28256f8adc8347ffc98932c"
                 ]
             ],
             [
@@ -72,10 +72,14 @@
                 ]
             ],
             [
-                "versions.yml:md5,cebe18512f616530fff490a64e595cb6"
+                "versions.yml:md5,4622a27c70440602e43a070716a16681"
             ]
         ],
-        "timestamp": "2024-01-03T00:05:48.225084591"
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-04-14T12:55:44.013430328"
     },
     "sarscov2 - genome - fasta - stub": {
         "content": [
@@ -88,7 +92,7 @@
                         {
                             "id": "test"
                         },
-                        "genome_taxonomy.tsv:md5,44c6cf5ff4c836f66648457ae8deb0d5"
+                        "genome_taxonomy.tsv:md5,be8ac66e3ea3a89ee6f41e08db79d0d6"
                     ]
                 ],
                 "10": [
@@ -96,7 +100,7 @@
                         {
                             "id": "test"
                         },
-                        "genome_virus_genes.tsv:md5,f84d8a9fce3c92c49e78672bea16561f"
+                        "genome_virus_genes.tsv:md5,f7970779d28256f8adc8347ffc98932c"
                     ]
                 ],
                 "11": [
@@ -116,7 +120,7 @@
                     ]
                 ],
                 "13": [
-                    "versions.yml:md5,cebe18512f616530fff490a64e595cb6"
+                    "versions.yml:md5,4622a27c70440602e43a070716a16681"
                 ],
                 "2": [
                     [
@@ -236,11 +240,11 @@
                         {
                             "id": "test"
                         },
-                        "genome_taxonomy.tsv:md5,44c6cf5ff4c836f66648457ae8deb0d5"
+                        "genome_taxonomy.tsv:md5,be8ac66e3ea3a89ee6f41e08db79d0d6"
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,cebe18512f616530fff490a64e595cb6"
+                    "versions.yml:md5,4622a27c70440602e43a070716a16681"
                 ],
                 "virus_fasta": [
                     [
@@ -255,7 +259,7 @@
                         {
                             "id": "test"
                         },
-                        "genome_virus_genes.tsv:md5,f84d8a9fce3c92c49e78672bea16561f"
+                        "genome_virus_genes.tsv:md5,f7970779d28256f8adc8347ffc98932c"
                     ]
                 ],
                 "virus_proteins": [
@@ -276,6 +280,10 @@
                 ]
             }
         ],
-        "timestamp": "2024-01-03T00:07:52.60021527"
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-04-14T12:58:05.749655103"
     }
 }


### PR DESCRIPTION
Previous Genomad version in conda tests pulled in the wrong version of a dependency. Module was quite out of date so bump the module version, which should also avoid this problem.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/metagenomeassembly/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
